### PR TITLE
Make styled-system, react peerDependencies

### DIFF
--- a/packages/clean-tag/package.json
+++ b/packages/clean-tag/package.json
@@ -12,7 +12,9 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {
-    "html-tags": "^2.0.0",
+    "html-tags": "^2.0.0"
+  },
+  "peerDependencies: {
     "react": "^16.8.5",
     "styled-system": "^3.2.1"
   },
@@ -23,7 +25,9 @@
     "@babel/register": "^7.4.0",
     "ava": "^1.3.1",
     "nyc": "^13.3.0",
-    "react-test-renderer": "^16.8.5"
+    "react-test-renderer": "^16.8.5",
+    "react": "^16.8.5",
+    "styled-system": "^3.2.1"
   },
   "ava": {
     "require": [

--- a/packages/clean-tag/package.json
+++ b/packages/clean-tag/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "html-tags": "^2.0.0"
   },
-  "peerDependencies: {
+  "peerDependencies": {
     "react": "^16.8.5",
     "styled-system": "^3.2.1"
   },

--- a/packages/clean-tag/package.json
+++ b/packages/clean-tag/package.json
@@ -15,8 +15,8 @@
     "html-tags": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.5",
-    "styled-system": "^3.2.1"
+    "react": ">=16.3",
+    "styled-system": ">=1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",


### PR DESCRIPTION
Just a little dependency clean up. We don't want styled-system or react to be direct dependencies because that could cause consumers to potentially end up including multiple versions of those dependencies in their bundles. 